### PR TITLE
update to new contract

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,16 +1,16 @@
 export const environments = [
   {
-    name: 'Production',
-    contractAddress: '0x30dB6Af76Ff4A9A30d7f927eFab235a7ea600e22',
+    name: "Production",
+    contractAddress: "0xDF686c48A8Cc5dF43c2b5b3086c4d77E9463Cac0",
   },
   {
-    name: 'Development',
-    contractAddress: '0xBD7F842Cb96dFF147d6b9b4c9f8e56acF76A969B',
+    name: "Development",
+    contractAddress: "0x40EC0E5FB2d22C1Bbf00662635eF8D20E22E8560",
   },
 ];
 
 export const network = {
-  ipfs: 'https://ipfs.infura.io/ipfs',
-  rpc: 'https://goerli.infura.io/v3/a4ba4d26c1a145999d11d2630ac5eb3c',
-  baseExplorerAPI: 'https://goerli.etherscan.io',
-}
+  ipfs: "https://ipfs.infura.io/ipfs",
+  rpc: "https://goerli.infura.io/v3/a4ba4d26c1a145999d11d2630ac5eb3c",
+  baseExplorerAPI: "https://goerli.etherscan.io",
+};

--- a/src/lib/contractABI.js
+++ b/src/lib/contractABI.js
@@ -1,693 +1,1027 @@
 const abi = [
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "poolId",
-        "type": "bytes32"
+        indexed: false,
+        internalType: "bytes32",
+        name: "poolId",
+        type: "bytes32",
       },
       {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "agentId",
-        "type": "bytes32"
+        indexed: false,
+        internalType: "bytes32",
+        name: "agentId",
+        type: "bytes32",
       },
       {
-        "indexed": false,
-        "internalType": "string",
-        "name": "ref",
-        "type": "string"
+        indexed: false,
+        internalType: "uint256",
+        name: "version",
+        type: "uint256",
       },
       {
-        "indexed": false,
-        "internalType": "address",
-        "name": "by",
-        "type": "address"
-      }
+        indexed: false,
+        internalType: "bool",
+        name: "latest",
+        type: "bool",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "by",
+        type: "address",
+      },
     ],
-    "name": "AgentAdded",
-    "type": "event"
+    name: "AgentAdded",
+    type: "event",
   },
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "poolId",
-        "type": "bytes32"
+        indexed: false,
+        internalType: "bytes32",
+        name: "poolId",
+        type: "bytes32",
       },
       {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "agentId",
-        "type": "bytes32"
+        indexed: false,
+        internalType: "bytes32",
+        name: "agentId",
+        type: "bytes32",
       },
       {
-        "indexed": false,
-        "internalType": "address",
-        "name": "admin",
-        "type": "address"
+        indexed: false,
+        internalType: "address",
+        name: "admin",
+        type: "address",
       },
       {
-        "indexed": false,
-        "internalType": "address",
-        "name": "by",
-        "type": "address"
-      }
+        indexed: false,
+        internalType: "address",
+        name: "by",
+        type: "address",
+      },
     ],
-    "name": "AgentAdminAdded",
-    "type": "event"
+    name: "AgentAdminAdded",
+    type: "event",
   },
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "poolId",
-        "type": "bytes32"
+        indexed: false,
+        internalType: "bytes32",
+        name: "poolId",
+        type: "bytes32",
       },
       {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "agentId",
-        "type": "bytes32"
+        indexed: false,
+        internalType: "bytes32",
+        name: "agentId",
+        type: "bytes32",
       },
       {
-        "indexed": false,
-        "internalType": "address",
-        "name": "admin",
-        "type": "address"
+        indexed: false,
+        internalType: "address",
+        name: "admin",
+        type: "address",
       },
       {
-        "indexed": false,
-        "internalType": "address",
-        "name": "by",
-        "type": "address"
-      }
+        indexed: false,
+        internalType: "address",
+        name: "by",
+        type: "address",
+      },
     ],
-    "name": "AgentAdminRemoved",
-    "type": "event"
+    name: "AgentAdminRemoved",
+    type: "event",
   },
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "poolId",
-        "type": "bytes32"
+        indexed: false,
+        internalType: "address",
+        name: "from",
+        type: "address",
       },
       {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "agentId",
-        "type": "bytes32"
+        indexed: false,
+        internalType: "address",
+        name: "to",
+        type: "address",
       },
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "by",
-        "type": "address"
-      }
     ],
-    "name": "AgentRemoved",
-    "type": "event"
+    name: "AgentRegistryChanged",
+    type: "event",
   },
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "poolId",
-        "type": "bytes32"
+        indexed: false,
+        internalType: "bytes32",
+        name: "poolId",
+        type: "bytes32",
       },
       {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "agentId",
-        "type": "bytes32"
+        indexed: false,
+        internalType: "bytes32",
+        name: "agentId",
+        type: "bytes32",
       },
       {
-        "indexed": false,
-        "internalType": "string",
-        "name": "ref",
-        "type": "string"
+        indexed: false,
+        internalType: "address",
+        name: "by",
+        type: "address",
       },
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "by",
-        "type": "address"
-      }
     ],
-    "name": "AgentUpdated",
-    "type": "event"
+    name: "AgentRemoved",
+    type: "event",
   },
   {
-    "anonymous": false,
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "poolId",
-        "type": "bytes32"
+        indexed: false,
+        internalType: "bytes32",
+        name: "poolId",
+        type: "bytes32",
       },
       {
-        "indexed": false,
-        "internalType": "address",
-        "name": "by",
-        "type": "address"
-      }
-    ],
-    "name": "PoolAdded",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "poolId",
-        "type": "bytes32"
+        indexed: false,
+        internalType: "bytes32",
+        name: "agentId",
+        type: "bytes32",
       },
       {
-        "indexed": false,
-        "internalType": "address",
-        "name": "addr",
-        "type": "address"
-      }
-    ],
-    "name": "PoolAdminAdded",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "poolId",
-        "type": "bytes32"
+        indexed: false,
+        internalType: "uint256",
+        name: "version",
+        type: "uint256",
       },
       {
-        "indexed": false,
-        "internalType": "address",
-        "name": "addr",
-        "type": "address"
-      }
-    ],
-    "name": "PoolAdminRemoved",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "poolId",
-        "type": "bytes32"
+        indexed: false,
+        internalType: "bool",
+        name: "latest",
+        type: "bool",
       },
       {
-        "indexed": false,
-        "internalType": "address",
-        "name": "from",
-        "type": "address"
+        indexed: false,
+        internalType: "address",
+        name: "by",
+        type: "address",
+      },
+    ],
+    name: "AgentUpdated",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "poolId",
+        type: "bytes32",
       },
       {
-        "indexed": false,
-        "internalType": "address",
-        "name": "to",
-        "type": "address"
-      }
+        indexed: false,
+        internalType: "address",
+        name: "by",
+        type: "address",
+      },
     ],
-    "name": "PoolOwnershipTransfered",
-    "type": "event"
+    name: "PoolAdded",
+    type: "event",
   },
   {
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "internalType": "bytes32",
-        "name": "_poolId",
-        "type": "bytes32"
+        indexed: false,
+        internalType: "bytes32",
+        name: "poolId",
+        type: "bytes32",
       },
       {
-        "internalType": "bytes32",
-        "name": "_agentId",
-        "type": "bytes32"
+        indexed: false,
+        internalType: "address",
+        name: "addr",
+        type: "address",
+      },
+    ],
+    name: "PoolAdminAdded",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "poolId",
+        type: "bytes32",
       },
       {
-        "internalType": "string",
-        "name": "_ref",
-        "type": "string"
-      }
+        indexed: false,
+        internalType: "address",
+        name: "addr",
+        type: "address",
+      },
     ],
-    "name": "addAgent",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    name: "PoolAdminRemoved",
+    type: "event",
   },
   {
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "internalType": "bytes32",
-        "name": "_poolId",
-        "type": "bytes32"
+        indexed: false,
+        internalType: "bytes32",
+        name: "poolId",
+        type: "bytes32",
       },
       {
-        "internalType": "bytes32",
-        "name": "_agentId",
-        "type": "bytes32"
+        indexed: false,
+        internalType: "address",
+        name: "from",
+        type: "address",
       },
       {
-        "internalType": "address",
-        "name": "_admin",
-        "type": "address"
-      }
+        indexed: false,
+        internalType: "address",
+        name: "to",
+        type: "address",
+      },
     ],
-    "name": "addAgentAdmin",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    name: "PoolOwnershipTransfered",
+    type: "event",
   },
   {
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "internalType": "bytes32",
-        "name": "_poolId",
-        "type": "bytes32"
-      }
-    ],
-    "name": "addPool",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "_poolId",
-        "type": "bytes32"
+        indexed: true,
+        internalType: "bytes32",
+        name: "role",
+        type: "bytes32",
       },
       {
-        "internalType": "address",
-        "name": "admin",
-        "type": "address"
-      }
-    ],
-    "name": "addPoolAdmin",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "_poolId",
-        "type": "bytes32"
+        indexed: true,
+        internalType: "bytes32",
+        name: "previousAdminRole",
+        type: "bytes32",
       },
       {
-        "internalType": "bytes32",
-        "name": "_agentId",
-        "type": "bytes32"
+        indexed: true,
+        internalType: "bytes32",
+        name: "newAdminRole",
+        type: "bytes32",
+      },
+    ],
+    name: "RoleAdminChanged",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "role",
+        type: "bytes32",
       },
       {
-        "internalType": "uint256",
-        "name": "index",
-        "type": "uint256"
-      }
-    ],
-    "name": "agentAdminAt",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "_poolId",
-        "type": "bytes32"
+        indexed: true,
+        internalType: "address",
+        name: "account",
+        type: "address",
       },
       {
-        "internalType": "bytes32",
-        "name": "_agentId",
-        "type": "bytes32"
-      }
+        indexed: true,
+        internalType: "address",
+        name: "sender",
+        type: "address",
+      },
     ],
-    "name": "agentAdminLength",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
+    name: "RoleGranted",
+    type: "event",
   },
   {
-    "inputs": [
+    anonymous: false,
+    inputs: [
       {
-        "internalType": "bytes32",
-        "name": "_poolId",
-        "type": "bytes32"
+        indexed: true,
+        internalType: "bytes32",
+        name: "role",
+        type: "bytes32",
       },
       {
-        "internalType": "uint256",
-        "name": "index",
-        "type": "uint256"
-      }
-    ],
-    "name": "agentAt",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
+        indexed: true,
+        internalType: "address",
+        name: "account",
+        type: "address",
       },
       {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
+        indexed: true,
+        internalType: "address",
+        name: "sender",
+        type: "address",
+      },
     ],
-    "stateMutability": "view",
-    "type": "function"
+    name: "RoleRevoked",
+    type: "event",
   },
   {
-    "inputs": [
+    inputs: [],
+    name: "ADMIN_ROLE",
+    outputs: [
       {
-        "internalType": "bytes32",
-        "name": "_poolId",
-        "type": "bytes32"
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "DEFAULT_ADMIN_ROLE",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_poolId",
+        type: "bytes32",
       },
       {
-        "internalType": "bytes32",
-        "name": "_agentId",
-        "type": "bytes32"
-      }
-    ],
-    "name": "agentExists",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "_poolId",
-        "type": "bytes32"
-      }
-    ],
-    "name": "agentLength",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "_poolId",
-        "type": "bytes32"
+        internalType: "bytes32",
+        name: "_agentId",
+        type: "bytes32",
       },
       {
-        "internalType": "bytes32",
-        "name": "_agentId",
-        "type": "bytes32"
-      }
-    ],
-    "name": "agentRef",
-    "outputs": [
-      {
-        "internalType": "string",
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "contract MinimalForwarderUpgradeable",
-        "name": "forwarder",
-        "type": "address"
-      }
-    ],
-    "name": "initialize",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "forwarder",
-        "type": "address"
-      }
-    ],
-    "name": "isTrustedForwarder",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "_poolId",
-        "type": "bytes32"
+        internalType: "uint256",
+        name: "version",
+        type: "uint256",
       },
       {
-        "internalType": "uint256",
-        "name": "index",
-        "type": "uint256"
-      }
+        internalType: "bool",
+        name: "latest",
+        type: "bool",
+      },
     ],
-    "name": "poolAdminAt",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
+    name: "addAgent",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "bytes32",
-        "name": "_poolId",
-        "type": "bytes32"
-      }
-    ],
-    "name": "poolAdminLength",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "name": "poolExistsMap",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "name": "poolOwners",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "name": "poolVersion",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "_poolId",
-        "type": "bytes32"
+        internalType: "bytes32",
+        name: "_poolId",
+        type: "bytes32",
       },
       {
-        "internalType": "bytes32",
-        "name": "_agentId",
-        "type": "bytes32"
-      }
+        internalType: "bytes32",
+        name: "_agentId",
+        type: "bytes32",
+      },
+      {
+        internalType: "address",
+        name: "_admin",
+        type: "address",
+      },
     ],
-    "name": "removeAgent",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    name: "addAgentAdmin",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "bytes32",
-        "name": "_poolId",
-        "type": "bytes32"
+        internalType: "bytes32",
+        name: "_poolId",
+        type: "bytes32",
       },
-      {
-        "internalType": "bytes32",
-        "name": "_agentId",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "address",
-        "name": "_admin",
-        "type": "address"
-      }
     ],
-    "name": "removeAgentAdmin",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    name: "addPool",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "bytes32",
-        "name": "_poolId",
-        "type": "bytes32"
+        internalType: "bytes32",
+        name: "_poolId",
+        type: "bytes32",
       },
       {
-        "internalType": "address",
-        "name": "admin",
-        "type": "address"
-      }
+        internalType: "address",
+        name: "admin",
+        type: "address",
+      },
     ],
-    "name": "removePoolAdmin",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    name: "addPoolAdmin",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "bytes32",
-        "name": "_poolId",
-        "type": "bytes32"
+        internalType: "bytes32",
+        name: "_poolId",
+        type: "bytes32",
       },
       {
-        "internalType": "address",
-        "name": "_to",
-        "type": "address"
-      }
+        internalType: "bytes32",
+        name: "_agentId",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint256",
+        name: "index",
+        type: "uint256",
+      },
     ],
-    "name": "transferPoolOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
+    name: "agentAdminAt",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
   },
   {
-    "inputs": [
+    inputs: [
       {
-        "internalType": "bytes32",
-        "name": "_poolId",
-        "type": "bytes32"
+        internalType: "bytes32",
+        name: "_poolId",
+        type: "bytes32",
       },
       {
-        "internalType": "bytes32",
-        "name": "_agentId",
-        "type": "bytes32"
+        internalType: "bytes32",
+        name: "_agentId",
+        type: "bytes32",
       },
-      {
-        "internalType": "string",
-        "name": "_ref",
-        "type": "string"
-      }
     ],
-    "name": "updateAgent",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  }
-]
+    name: "agentAdminLength",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_poolId",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint256",
+        name: "index",
+        type: "uint256",
+      },
+    ],
+    name: "agentAt",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+      {
+        internalType: "string",
+        name: "",
+        type: "string",
+      },
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_poolId",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "_agentId",
+        type: "bytes32",
+      },
+    ],
+    name: "agentExists",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_poolId",
+        type: "bytes32",
+      },
+    ],
+    name: "agentLength",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_poolId",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "_agentId",
+        type: "bytes32",
+      },
+    ],
+    name: "agentRef",
+    outputs: [
+      {
+        internalType: "string",
+        name: "",
+        type: "string",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    name: "agentUsingLatest",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    name: "agentVersion",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_poolId",
+        type: "bytes32",
+      },
+    ],
+    name: "getPoolHash",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "role",
+        type: "bytes32",
+      },
+    ],
+    name: "getRoleAdmin",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "role",
+        type: "bytes32",
+      },
+      {
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+    ],
+    name: "grantRole",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "role",
+        type: "bytes32",
+      },
+      {
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+    ],
+    name: "hasRole",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "contract MinimalForwarderUpgradeable",
+        name: "forwarder",
+        type: "address",
+      },
+    ],
+    name: "initialize",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "forwarder",
+        type: "address",
+      },
+    ],
+    name: "isTrustedForwarder",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_poolId",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint256",
+        name: "index",
+        type: "uint256",
+      },
+    ],
+    name: "poolAdminAt",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_poolId",
+        type: "bytes32",
+      },
+    ],
+    name: "poolAdminLength",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    name: "poolExistsMap",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    name: "poolOwners",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_poolId",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "_agentId",
+        type: "bytes32",
+      },
+    ],
+    name: "removeAgent",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_poolId",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "_agentId",
+        type: "bytes32",
+      },
+      {
+        internalType: "address",
+        name: "_admin",
+        type: "address",
+      },
+    ],
+    name: "removeAgentAdmin",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_poolId",
+        type: "bytes32",
+      },
+      {
+        internalType: "address",
+        name: "admin",
+        type: "address",
+      },
+    ],
+    name: "removePoolAdmin",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "role",
+        type: "bytes32",
+      },
+      {
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+    ],
+    name: "renounceRole",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "role",
+        type: "bytes32",
+      },
+      {
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+    ],
+    name: "revokeRole",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_addr",
+        type: "address",
+      },
+    ],
+    name: "setAgentRegistry",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes4",
+        name: "interfaceId",
+        type: "bytes4",
+      },
+    ],
+    name: "supportsInterface",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_poolId",
+        type: "bytes32",
+      },
+      {
+        internalType: "address",
+        name: "_to",
+        type: "address",
+      },
+    ],
+    name: "transferPoolOwnership",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "_poolId",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "_agentId",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint256",
+        name: "version",
+        type: "uint256",
+      },
+      {
+        internalType: "bool",
+        name: "latest",
+        type: "bool",
+      },
+    ],
+    name: "updateAgent",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+];
 
 export default abi;

--- a/src/slices/appSlice.ts
+++ b/src/slices/appSlice.ts
@@ -59,7 +59,6 @@ export const loadAgent = createAsyncThunk(
       state.app.environment.contractAddress
     );
     const agent = await contract.getAgentAt(poolId, index);
-    console.log(agent);
     const { manifest } = await fetch(`${network.ipfs}/${agent[3]}`).then(
       (response) => {
         if (!response.ok) {

--- a/src/slices/appSlice.ts
+++ b/src/slices/appSlice.ts
@@ -1,7 +1,7 @@
-import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { RootState } from '../app/store';
-import { environments, network } from '../config';
-import ContractInteractor from '../lib/ContractInteractor';
+import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { RootState } from "../app/store";
+import { environments, network } from "../config";
+import ContractInteractor from "../lib/ContractInteractor";
 
 type Environment = {
   name: string;
@@ -9,24 +9,24 @@ type Environment = {
 };
 
 export interface AppState {
-  environment: Environment,
-  suggestedPools: string[],
-  suggestedPoolsLoading: boolean,
+  environment: Environment;
+  suggestedPools: string[];
+  suggestedPoolsLoading: boolean;
   pool: {
-    loading: boolean,
-    error: string | null | undefined,
-    id: string,
-    name: string
-  },
+    loading: boolean;
+    error: string | null | undefined;
+    id: string;
+    name: string;
+  };
   agents: {
-    loading: boolean,
-    id: string,
-    name: string,
-    reference: string,
-    version: string,
-    fromAddress: string,
-    date: string,
-  }[],
+    loading: boolean;
+    id: string;
+    name: string;
+    reference: string;
+    version: string;
+    fromAddress: string;
+    date: string;
+  }[];
 }
 
 const initialState: AppState = {
@@ -39,11 +39,11 @@ const initialState: AppState = {
     id: null,
     name: null,
   },
-  agents: []
+  agents: [],
 };
 
 export const loadPoolIds = createAsyncThunk(
-  'app/loadPoolIds',
+  "app/loadPoolIds",
   async (contractAddress: string) => {
     const contract = new ContractInteractor(contractAddress);
     return await contract.getPoolIds();
@@ -51,23 +51,27 @@ export const loadPoolIds = createAsyncThunk(
 );
 
 export const loadAgent = createAsyncThunk(
-  'app/loadAgent',
-  async ({poolId, index}: {poolId: string, index: number}, thunkAPI) => {
+  "app/loadAgent",
+  async ({ poolId, index }: { poolId: string; index: number }, thunkAPI) => {
     // @ts-ignore
     const state: RootState = thunkAPI.getState();
-    const contract = new ContractInteractor(state.app.environment.contractAddress);
+    const contract = new ContractInteractor(
+      state.app.environment.contractAddress
+    );
     const agent = await contract.getAgentAt(poolId, index);
-    const {manifest} = await fetch(`${network.ipfs}/${agent[1]}`)
-      .then(response => {
+    console.log(agent);
+    const { manifest } = await fetch(`${network.ipfs}/${agent[3]}`).then(
+      (response) => {
         if (!response.ok) {
-            throw new Error("HTTP error " + response.status);
+          throw new Error("HTTP error " + response.status);
         }
         return response.json();
-      });
+      }
+    );
     return {
       id: agent[0],
       name: manifest.agentId,
-      reference: agent[1],
+      reference: agent[3],
       from: manifest.from,
       version: manifest.version,
       date: manifest.timestamp,
@@ -78,30 +82,32 @@ export const loadAgent = createAsyncThunk(
 );
 
 export const loadPool = createAsyncThunk(
-  'app/loadPool',
+  "app/loadPool",
   async (poolId: string, thunkAPI) => {
-    if(!poolId) {
+    if (!poolId) {
       return {
         poolId: null,
-        agentsLength: 0
+        agentsLength: 0,
       };
     }
     // @ts-ignore
     const state: RootState = thunkAPI.getState();
-    const contract = new ContractInteractor(state.app.environment.contractAddress);
+    const contract = new ContractInteractor(
+      state.app.environment.contractAddress
+    );
     const agentsLength = (await contract.getAgentsLength(poolId)).toNumber();
-    for(let index=0; index < agentsLength; index++) {
-      thunkAPI.dispatch(loadAgent({poolId, index}))
+    for (let index = 0; index < agentsLength; index++) {
+      thunkAPI.dispatch(loadAgent({ poolId, index }));
     }
     return {
       poolId,
-      agentsLength
+      agentsLength,
     };
   }
 );
 
 export const appSlice = createSlice({
-  name: 'app',
+  name: "app",
   initialState,
   reducers: {
     setEnvironment: (state, action: PayloadAction<Environment>) => {
@@ -123,23 +129,25 @@ export const appSlice = createSlice({
       })
       .addCase(loadPool.rejected, (state, action) => {
         state.pool.loading = false;
-        state.pool.error = 'Pool not found';
+        state.pool.error = "Pool not found";
       })
       .addCase(loadPool.fulfilled, (state, action) => {
         state.pool.loading = false;
         state.pool.id = action.payload.poolId;
         state.pool.error = null;
-        state.agents = [...Array(action.payload.agentsLength)].map((_, index) => {
-          return {
-            loading: true,
-            id: '',
-            name: '',
-            reference: '',
-            version: '',
-            fromAddress: '',
-            date: '',
-          };
-        });
+        state.agents = [...Array(action.payload.agentsLength)].map(
+          (_, index) => {
+            return {
+              loading: true,
+              id: "",
+              name: "",
+              reference: "",
+              version: "",
+              fromAddress: "",
+              date: "",
+            };
+          }
+        );
       })
       .addCase(loadAgent.fulfilled, (state, { payload }) => {
         state.agents[payload.index] = {
@@ -159,7 +167,7 @@ export const appSlice = createSlice({
       .addCase(loadPoolIds.fulfilled, (state, { payload }) => {
         state.suggestedPoolsLoading = false;
         state.suggestedPools = payload;
-      })
+      });
   },
 });
 


### PR DESCRIPTION
- this points the explorer to the new contract (different address + method, but very similar)
- I have prettier running on save, so it swapped out some quotes in that formatting (sorry)